### PR TITLE
feat: drop disputed claims

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -7,6 +7,8 @@ remappings = [
   "@openzeppelin/=lib/openzeppelin-contracts/",
 ]
 
+solc_version = "0.8.24"
+evm_version = "shanghai"
 via_ir = true
 
 [rpc_endpoints]

--- a/foundry.toml
+++ b/foundry.toml
@@ -14,10 +14,12 @@ via_ir = true
 [rpc_endpoints]
 goerli = "${ETH_RPC_URL}"
 mainnet = "${ETH_RPC_URL}"
+arbitrum = "${ETH_RPC_URL}"
 
 [etherscan]
 goerli = { url = "https://api-goerli.etherscan.io/api", key = "${ETHERSCAN_API_KEY}", chain = 5 }
 mainnet = { url = "https://api.etherscan.io/api", key = "${ETHERSCAN_API_KEY}", chain = 1 }
+arbitrum = { url = "https://api.arbiscan.io/api", key = "${ETHERSCAN_API_KEY}", chain = 42161 }
 
 [fmt]
 tab_width = 2

--- a/sample-proposal.json
+++ b/sample-proposal.json
@@ -7,20 +7,20 @@
 		"external": {
 			"ethOracle": {
 				"sourceChainId": "5",
-				"address": "0xFe6Cbc9179a68f1029570269cF41333B9911b831.",
+				"address": "0xFe6Cbc9179a68f1029570269cF41333B9911b831",
 				"abi": "[{\"type\":\"function\",\"name\":\"getData\",\"inputs\":[{\"name\":\"identifier\",\"type\":\"tuple\",\"internalType\":\"struct TerminationOracle.Identifier\",\"components\":[{\"name\":\"bondCurrency\",\"type\":\"address\",\"internalType\":\"contract IERC20\"},{\"name\":\"minimumBond\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"maximumBond\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"liveness\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"marketCode\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"quoteName\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"enactmentDate\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"ipfsLink\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"conditionalSettlementOracle\",\"type\":\"address\",\"internalType\":\"contract SettlementOracle\"}]}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"}]",
 				"method": "getData",
 				"args": [
 					{
-						"liveness": "120",
+						"liveness": 120,
 						"bondCurrency": "0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6",
-						"minimumBond": "1000000000",
-						"maximumBond": "100000000000",
+						"minimumBond": 1000000000,
+						"maximumBond": 100000000000,
 						"ipfsLink": "ipfs:foo.bar",
 						"marketCode": "SOL/USDT",
 						"quoteName": "USDT",
 						"enactmentDate": "2024-02-22T02:00:00Z",
-						"conditionalSettlementOracle": "0xB92997f94F4F3caCe123B13627EB68AdC3B7b091."
+						"conditionalSettlementOracle": "0xB92997f94F4F3caCe123B13627EB68AdC3B7b091"
 					}
 				],
 				"requiredConfirmations": "64",
@@ -72,15 +72,15 @@
 		"external": {
 			"ethOracle": {
 				"sourceChainId": "5",
-				"address": "0xB92997f94F4F3caCe123B13627EB68AdC3B7b091.",
+				"address": "0xB92997f94F4F3caCe123B13627EB68AdC3B7b091",
 				"abi": "[{\"type\":\"function\",\"name\":\"getData\",\"inputs\":[{\"name\":\"identifier\",\"type\":\"tuple\",\"internalType\":\"struct SettlementOracle.Identifier\",\"components\":[{\"name\":\"liveness\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"bondCurrency\",\"type\":\"address\",\"internalType\":\"contract IERC20\"},{\"name\":\"minimumBond\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"maximumBond\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"marketCode\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"quoteName\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"enactmentDate\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"ipfsLink\",\"type\":\"string\",\"internalType\":\"string\"}]}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"}]",
 				"method": "getData",
 				"args": [
 					{
-						"liveness": "120",
+						"liveness": 120,
 						"bondCurrency": "0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6",
-						"minimumBond": "1000000000",
-						"maximumBond": "100000000000",
+						"minimumBond": 1000000000,
+						"maximumBond": 100000000000,
 						"ipfsLink": "ipfs:foo.bar",
 						"marketCode": "SOL/USDT",
 						"quoteName": "USDT",

--- a/sample-proposal.json
+++ b/sample-proposal.json
@@ -7,18 +7,23 @@
 		"external": {
 			"ethOracle": {
 				"sourceChainId": "5",
-				"address": "0x7D6aa06a128f161945cD6aa6b267738f3e542551",
-				"abi": "[{\"type\":\"function\",\"name\":\"getData\",\"inputs\":[{\"name\":\"identifier\",\"type\":\"tuple\",\"internalType\":\"struct TerminationOracle.Identifier\",\"components\":[{\"name\":\"marketCode\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"quoteName\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"enactmentDate\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"conditionalSettlementOracle\",\"type\":\"address\",\"internalType\":\"contract SettlementOracle\"}]}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"}]",
+				"address": "0xFe6Cbc9179a68f1029570269cF41333B9911b831.",
+				"abi": "[{\"type\":\"function\",\"name\":\"getData\",\"inputs\":[{\"name\":\"identifier\",\"type\":\"tuple\",\"internalType\":\"struct TerminationOracle.Identifier\",\"components\":[{\"name\":\"bondCurrency\",\"type\":\"address\",\"internalType\":\"contract IERC20\"},{\"name\":\"minimumBond\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"maximumBond\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"liveness\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"marketCode\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"quoteName\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"enactmentDate\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"ipfsLink\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"conditionalSettlementOracle\",\"type\":\"address\",\"internalType\":\"contract SettlementOracle\"}]}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"}]",
 				"method": "getData",
 				"args": [
 					{
+						"liveness": "120",
+						"bondCurrency": "0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6",
+						"minimumBond": "1000000000",
+						"maximumBond": "100000000000",
+						"ipfsLink": "ipfs:foo.bar",
 						"marketCode": "SOL/USDT",
 						"quoteName": "USDT",
 						"enactmentDate": "2024-02-22T02:00:00Z",
-						"conditionalSettlementOracle": "0x9Dc85d557BF18441F20a2fC292730f956eC43466"
+						"conditionalSettlementOracle": "0xB92997f94F4F3caCe123B13627EB68AdC3B7b091."
 					}
 				],
-				"requiredConfirmations": "3",
+				"requiredConfirmations": "64",
 				"trigger": {
 					"timeTrigger": {
 						"every": "60"
@@ -34,18 +39,6 @@
 							{
 								"operator": "OPERATOR_EQUALS",
 								"value": "true"
-							}
-						]
-					},
-					{
-						"key": {
-							"name": "terminationTimestamp",
-							"type": "TYPE_INTEGER"
-						},
-						"conditions": [
-							{
-								"operator": "OPERATOR_LESS_THAN",
-								"value": "vegaprotocol.builtin.timestamp"
 							}
 						]
 					},
@@ -68,10 +61,6 @@
 						"expression": "$[0]"
 					},
 					{
-						"name": "terminationTimestamp",
-						"expression": "$[1]"
-					},
-					{
 						"name": "terminated",
 						"expression": "$[2]"
 					}
@@ -83,17 +72,22 @@
 		"external": {
 			"ethOracle": {
 				"sourceChainId": "5",
-				"address": "0x9Dc85d557BF18441F20a2fC292730f956eC43466",
-				"abi": "[{\"type\":\"function\",\"name\":\"getData\",\"inputs\":[{\"name\":\"identifier\",\"type\":\"tuple\",\"internalType\":\"struct SettlementOracle.Identifier\",\"components\":[{\"name\":\"marketCode\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"quoteName\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"enactmentDate\",\"type\":\"string\",\"internalType\":\"string\"}]}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"}]",
+				"address": "0xB92997f94F4F3caCe123B13627EB68AdC3B7b091.",
+				"abi": "[{\"type\":\"function\",\"name\":\"getData\",\"inputs\":[{\"name\":\"identifier\",\"type\":\"tuple\",\"internalType\":\"struct SettlementOracle.Identifier\",\"components\":[{\"name\":\"liveness\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"bondCurrency\",\"type\":\"address\",\"internalType\":\"contract IERC20\"},{\"name\":\"minimumBond\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"maximumBond\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"marketCode\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"quoteName\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"enactmentDate\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"ipfsLink\",\"type\":\"string\",\"internalType\":\"string\"}]}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"}]",
 				"method": "getData",
 				"args": [
 					{
+						"liveness": "120",
+						"bondCurrency": "0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6",
+						"minimumBond": "1000000000",
+						"maximumBond": "100000000000",
+						"ipfsLink": "ipfs:foo.bar",
 						"marketCode": "SOL/USDT",
 						"quoteName": "USDT",
 						"enactmentDate": "2024-02-22T02:00:00Z"
 					}
 				],
-				"requiredConfirmations": "3",
+				"requiredConfirmations": "64",
 				"trigger": {
 					"timeTrigger": {
 						"every": "60"
@@ -109,6 +103,19 @@
 							{
 								"operator": "OPERATOR_EQUALS",
 								"value": "true"
+							}
+						]
+					},
+					{
+						"key": {
+							"name": "price",
+							"type": "TYPE_INTEGER",
+							"decimalPlaces": "18"
+						},
+						"conditions": [
+							{
+								"operator": "OPERATOR_GREATER_THAN_OR_EQUAL",
+								"value": "0"
 							}
 						]
 					}

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -38,8 +38,8 @@ contract DeployScript is Script {
       weth.deposit{value: 1 ether}();
     }
 
-    SettlementOracle so = new SettlementOracle(oracleAddress, wethAddress, 2 minutes);
-    TerminationOracle to = new TerminationOracle(oracleAddress, wethAddress, 2 minutes);
+    SettlementOracle so = new SettlementOracle(oracleAddress);
+    TerminationOracle to = new TerminationOracle(oracleAddress);
 
     weth.approve(address(so), 0.5 ether);
     weth.approve(address(to), 0.5 ether);

--- a/src/BaseOracle.sol
+++ b/src/BaseOracle.sol
@@ -102,7 +102,7 @@ contract BaseOracle {
 
   /// @dev Internal id helper function.
   function _id(bytes memory entropy) internal view returns (bytes32) {
-    return keccak256(abi.encode(address(this), entropy));
+    return keccak256(abi.encode(block.chainid, address(this), entropy));
   }
 
   function _getClaim(bytes32 claimId) internal view returns (Claim memory) {

--- a/src/BaseOracle.sol
+++ b/src/BaseOracle.sol
@@ -71,7 +71,7 @@ contract BaseOracle {
   function assertionResolvedCallback(bytes32 assertionId, bool result) external onlyOracle {
     bytes32 claimId = assertionToClaimId[assertionId];
     if (claimId == 0) {
-      revert ClaimNotFound();
+      return;
     }
 
     if (result) {
@@ -91,8 +91,11 @@ contract BaseOracle {
   function assertionDisputedCallback(bytes32 assertionId) external onlyOracle {
     bytes32 claimId = assertionToClaimId[assertionId];
     if (claimId == 0) {
-      revert ClaimNotFound();
+      return;
     }
+
+    delete claims[claimId];
+    delete assertionToClaimId[assertionId];
 
     emit Disputed(claimId, assertionId);
   }
@@ -119,4 +122,3 @@ contract BaseOracle {
     }
   }
 }
-

--- a/src/BaseOracle.sol
+++ b/src/BaseOracle.sol
@@ -10,6 +10,7 @@ import {OptimisticOracleV3Interface} from
 error ClaimNotFound();
 error ClaimAlreadySubmitted(bytes32 assertionId);
 error Unauthorized();
+error BondOutOfRange(uint256 minimumBond, uint256 maximumBond, uint256 bond);
 
 contract BaseOracle {
   struct Claim {
@@ -28,17 +29,10 @@ contract BaseOracle {
   mapping(bytes32 => Claim) public claims;
   mapping(bytes32 => bytes32) public assertionToClaimId;
 
-  IERC20 public immutable bondCurrency;
   OptimisticOracleV3Interface public immutable oracle;
-  uint64 public immutable liveness;
 
-  constructor(address _oracle, address _bondCurrency, uint64 _liveness) {
-    bondCurrency = IERC20(_bondCurrency);
+  constructor(address _oracle) {
     oracle = OptimisticOracleV3Interface(_oracle);
-    liveness = _liveness;
-
-    // Unconditionally approve the oracle to transfer the bond currency.
-    bondCurrency.approve(_oracle, type(uint256).max);
   }
 
   modifier onlyOracle() {

--- a/src/BaseOracle.sol
+++ b/src/BaseOracle.sol
@@ -13,6 +13,10 @@ error Unauthorized();
 error BondOutOfRange(uint256 minimumBond, uint256 maximumBond, uint256 bond);
 
 contract BaseOracle {
+  /// @dev `Claim` contains a OOv3 `assertionId`, the result of the claim and any additional data provided by child contracts.
+  /// @param assertionId The identifier of the assertion provided by OOv3
+  /// @param data Additional data provided by child contracts. Can be stored with `abi.encode()` and decoded with `abi.decode(claim.data, (TYPE))`.
+  /// @param result The result of the claim. Will be `false` by default, but resolve to `true` if the claim is accepted.
   struct Claim {
     bytes32 assertionId;
     bytes data;
@@ -20,10 +24,17 @@ contract BaseOracle {
   }
 
   /// @dev Emitted when a claim is submitted to OOv3.
+  /// @param claimId The identifier of the claim as returned by `id()`.
+  /// @param assertionId The identifier of the assertion as returned by OOv3.
   event Submitted(bytes32 indexed claimId, bytes32 indexed assertionId);
   /// @dev Emitted when a claim is resolved by OOv3.
+  /// @param result The result of the claim. Will be `true` if the claim is accepted, `false` if it is rejected.
+  /// @param claimId The identifier of the claim as returned by `id()`.
+  /// @param assertionId The identifier of the assertion as returned by OOv3.
   event Resolved(bool result, bytes32 indexed claimId, bytes32 indexed assertionId);
   /// @dev Emitted when a claim is disputed by OOv3. This does not necessarily mean the claim is rejected.
+  /// @param claimId The identifier of the claim as returned by `id()`.
+  /// @param assertionId The identifier of the assertion as returned by OOv3.
   event Disputed(bytes32 indexed claimId, bytes32 indexed assertionId);
 
   mapping(bytes32 => Claim) public claims;

--- a/src/BaseOracle.sol
+++ b/src/BaseOracle.sol
@@ -1,4 +1,4 @@
-// SPDX-license-identifier: MIT
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/src/SettlementOracle.sol
+++ b/src/SettlementOracle.sol
@@ -11,9 +11,24 @@ import {
   BondOutOfRange
 } from "./BaseOracle.sol";
 
+/// @title SettlementOracle
+/// @notice This contract serves as an oracle for setteling VEGA markets using the UMA Protocol and Optimistic Oracle v3.
+/// @inheritdoc BaseOracle
 contract SettlementOracle is BaseOracle {
   using SafeERC20 for IERC20;
 
+  /// @notice `Identifier` values must match the exact values used in the VEGA market proposal. Any small deviation will result in any claims not being read correctly by VEGAs ethereum oracle functionality.
+  /// @dev `Identifier` represents a unique set of human readable values that is used to generate an internal `bytes32` ID, often referred to as `claimId`.
+  /// @dev The mix of properties should be values that are known at the time the VEGA market is proposed and must not overlap with any other past or future market.
+  /// @dev `Identifier` can be considered a form of "commitment" that will be "revealed" in the future by someone making a claim.
+  /// @param liveness The time in seconds that the claim will be open for dispute.
+  /// @param bondCurrency The currency used as a bond to the claim. Must be an UMA approved token. The asserter must approve this contract to transfer the bond amount.
+  /// @param minimumBond The minimum bond amount required to make a claim.
+  /// @param maximumBond The maximum bond amount allowed to make a claim.
+  /// @param marketCode The identifier of the VEGA market as per the VEGA market proposal.
+  /// @param quoteName The name of the quote currency as per the VEGA market proposal.
+  /// @param enactmentDate The date the VEGA market is enacted as per the VEGA market proposal. Should be ISO 8601 format.
+  /// @param ipfsLink A link to the IPFS file containing the validation instructions.
   struct Identifier {
     uint64 liveness;
     IERC20 bondCurrency;
@@ -25,10 +40,16 @@ contract SettlementOracle is BaseOracle {
     string ipfsLink;
   }
 
+  /// @notice `Data` represents structured data attached to a claim and readable by VEGA through the `getData` function.
+  /// @param price The price at which the VEGA market is settled.
   struct Data {
     uint256 price;
   }
 
+  /// @notice `claimText` is a helper function to generate the text that will be attached to the claim and must be human readable, and provide clear instructions on how to validate the claim.
+  /// @param identifier The identifier of the claim.
+  /// @param data The data of the claim.
+  /// @return The text that will be attached to the claim.
   function claimText(Identifier memory identifier, Data memory data) public pure returns (bytes memory) {
     return abi.encodePacked(
       "Settling VEGA market ",
@@ -44,10 +65,17 @@ contract SettlementOracle is BaseOracle {
     );
   }
 
+  /// @notice `id` is a helper function to generate the `bytes32` ID of a claim.
+  /// @param identifier The identifier of the claim.
+  /// @return The `bytes32` ID of the claim.
   function id(Identifier calldata identifier) public view returns (bytes32) {
     return _id(abi.encode(identifier));
   }
 
+  /// @notice `getData` is the primary function to read the structured data attached to a claim.
+  /// @notice This function is more expensive to call on-chaon than `getCachedData` as it reads the claim resolution directly from the OOv3 contract. This means it will always return the most up to date information, without needing callback from UMA OOv3.
+  /// @param identifier The identifier of the claim.
+  /// @return A tuple containing the result of the claim, and the price at which the VEGA market is settled.
   function getData(Identifier calldata identifier) public view returns (bool, uint256) {
     Claim memory claim = _getClaim(id(identifier));
     bool result = _getAssertionResult(claim.assertionId);
@@ -57,6 +85,9 @@ contract SettlementOracle is BaseOracle {
     return (result, data.price);
   }
 
+  /// @notice `getCachedData` is a helper function to read the structured data attached to a claim. The result is based on data stored in this contract only and may not have the most up to date resolution from UMA OOv3.
+  /// @param identifier The identifier of the claim.
+  /// @return A tuple containing the result of the claim, and the price at which the VEGA market is settled.
   function getCachedData(Identifier calldata identifier) public view returns (bool, uint256) {
     Claim memory claim = _getClaim(id(identifier));
     Data memory data = abi.decode(claim.data, (Data));
@@ -66,14 +97,29 @@ contract SettlementOracle is BaseOracle {
 
   constructor(address _oracle) BaseOracle(_oracle) {}
 
+  /// @notice Submit a claim to the oracle. This function will use the minimum bond amount required to make a claim and the sender as the asserter. This means the bond will be returned to the sender if successfully resolved.
+  /// @notice You must approve the bond currency to this contract before calling this function.
+  /// @notice A claim can only be submitted once for each `Identifier`, except if the claim is disputed. In that case, a new claim can immediately be submitted.
+  /// @param identifier The identifier of the claim. The provided identifier must match the exact values used in the VEGA market proposal.
+  /// @param data The data of the claim.
   function submitClaim(Identifier calldata identifier, Data calldata data) public {
     return submitClaim(identifier, data, identifier.minimumBond, msg.sender);
   }
 
+  /// @notice Submit a claim to the oracle. This function lets you specify the bond amount, withing the minimum and maximum bond range, and the sender as the asserter. This means the bond will be returned to the sender if successfully resolved.
+  /// @notice You must approve the bond currency to this contract before calling this function.
+  /// @notice A claim can only be submitted once for each `Identifier`, except if the claim is disputed. In that case, a new claim can immediately be submitted.
+  /// @param identifier The identifier of the claim. The provided identifier must match the exact values used in the VEGA market proposal.
+  /// @param data The data of the claim.
   function submitClaim(Identifier calldata identifier, Data calldata data, uint256 bondAmount) public {
     return submitClaim(identifier, data, bondAmount, msg.sender);
   }
 
+  /// @notice Submit a claim to the oracle. This function lets you specify the bond amount, withing the minimum and maximum bond range, and the asserter. The asserter will recieve the bond back if the claim is successfully resolved.
+  /// @notice You must approve the bond currency to this contract before calling this function.
+  /// @notice A claim can only be submitted once for each `Identifier`, except if the claim is disputed. In that case, a new claim can immediately be submitted.
+  /// @param identifier The identifier of the claim. The provided identifier must match the exact values used in the VEGA market proposal.
+  /// @param data The data of the claim.
   function submitClaim(Identifier calldata identifier, Data calldata data, uint256 bondAmount, address asserter) public {
     if (identifier.minimumBond > bondAmount || bondAmount > identifier.maximumBond) {
       revert BondOutOfRange(identifier.minimumBond, identifier.maximumBond, bondAmount);
@@ -112,11 +158,9 @@ contract SettlementOracle is BaseOracle {
     emit Submitted(claimId, assertionId);
   }
 
-  /**
-   * @notice Finalize a claim by settling the associated assertion, and release the bond.
-   * @notice This function is more expensive to call than setteling directly with the OOv3 contract or through the UMA dApp. However it provides the convenience of resolving the assertionId from the claim identifier.
-   * @param identifier The identifier of the claim to finalize.
-   */
+  /// @notice Finalize a claim by settling the associated assertion, and release the bond.
+  /// @notice This function is more expensive to call than setteling directly with the OOv3 contract or through the UMA dApp. However it provides the convenience of resolving the assertionId from the claim identifier.
+  /// @param identifier The identifier of the claim to finalize.
   function finalizeClaim(Identifier calldata identifier) external {
     bytes32 claimId = id(identifier);
     return _finalizeClaim(claimId);

--- a/src/TerminationOracle.sol
+++ b/src/TerminationOracle.sol
@@ -2,7 +2,13 @@
 pragma solidity ^0.8.0;
 
 import {
-  BaseOracle, IERC20, SafeERC20, Strings, OptimisticOracleV3Interface, ClaimAlreadySubmitted
+  BaseOracle,
+  IERC20,
+  SafeERC20,
+  Strings,
+  OptimisticOracleV3Interface,
+  ClaimAlreadySubmitted,
+  BondOutOfRange
 } from "./BaseOracle.sol";
 import {SettlementOracle} from "./SettlementOracle.sol";
 
@@ -10,9 +16,14 @@ contract TerminationOracle is BaseOracle {
   using SafeERC20 for IERC20;
 
   struct Identifier {
+    IERC20 bondCurrency;
+    uint256 minimumBond;
+    uint256 maximumBond;
+    uint64 liveness;
     string marketCode;
     string quoteName;
     string enactmentDate;
+    string ipfsLink;
     SettlementOracle conditionalSettlementOracle;
   }
 
@@ -22,7 +33,7 @@ contract TerminationOracle is BaseOracle {
 
   function claimText(Identifier memory identifier, Data memory data) public pure returns (bytes memory) {
     return abi.encodePacked(
-      "Claiming ",
+      "Terminating VEGA market ",
       identifier.marketCode,
       " settled in ",
       identifier.quoteName,
@@ -30,8 +41,14 @@ contract TerminationOracle is BaseOracle {
       identifier.enactmentDate,
       ", to terminate at ",
       Strings.toString(data.terminationTimestamp),
-      " conditionally terminated by settlement oracle at ",
-      Strings.toHexString(address(identifier.conditionalSettlementOracle))
+      address(identifier.conditionalSettlementOracle) == address(0)
+        ? bytes("")
+        : abi.encodePacked(
+          " conditionally terminated by settlement oracle at ",
+          Strings.toHexString(address(identifier.conditionalSettlementOracle))
+        ),
+      ".\n IPFS link to validation instructions: ",
+      identifier.ipfsLink
     );
   }
 
@@ -40,16 +57,12 @@ contract TerminationOracle is BaseOracle {
   }
 
   function getData(Identifier calldata identifier) public view returns (bool, uint256, bool) {
-    SettlementOracle so2 = identifier.conditionalSettlementOracle;
-    try so2.getData(
-      SettlementOracle.Identifier({
-        marketCode: identifier.marketCode,
-        quoteName: identifier.quoteName,
-        enactmentDate: identifier.enactmentDate
-      })
-    ) returns (bool hasSettled, uint256) {
-      return (hasSettled, 0, true);
-    } catch {}
+    if (address(identifier.conditionalSettlementOracle) != address(0)) {
+      SettlementOracle so2 = identifier.conditionalSettlementOracle;
+      try so2.getData(_settlementIdentifier(identifier)) returns (bool hasResolved, uint256) {
+        return (hasResolved, 0, hasResolved);
+      } catch {}
+    }
 
     Claim memory claim = _getClaim(id(identifier));
     bool result = _getAssertionResult(claim.assertionId);
@@ -60,16 +73,12 @@ contract TerminationOracle is BaseOracle {
   }
 
   function getCachedData(Identifier calldata identifier) public view returns (bool, uint256, bool) {
-    SettlementOracle so2 = identifier.conditionalSettlementOracle;
-    try so2.getCachedData(
-      SettlementOracle.Identifier({
-        marketCode: identifier.marketCode,
-        quoteName: identifier.quoteName,
-        enactmentDate: identifier.enactmentDate
-      })
-    ) returns (bool hasSettled, uint256) {
-      return (hasSettled, 0, true);
-    } catch {}
+    if (address(identifier.conditionalSettlementOracle) != address(0)) {
+      SettlementOracle so2 = identifier.conditionalSettlementOracle;
+      try so2.getCachedData(_settlementIdentifier(identifier)) returns (bool hasResolved, uint256) {
+        return (hasResolved, 0, hasResolved);
+      } catch {}
+    }
 
     Claim memory claim = _getClaim(id(identifier));
 
@@ -78,27 +87,62 @@ contract TerminationOracle is BaseOracle {
     return (claim.result, data.terminationTimestamp, block.timestamp >= data.terminationTimestamp);
   }
 
-  constructor(address _oracle, address _bondCurrency, uint64 _liveness)
-    BaseOracle(_oracle, _bondCurrency, _liveness)
-  {}
+  function _settlementIdentifier(Identifier calldata identifier)
+    internal
+    pure
+    returns (SettlementOracle.Identifier memory)
+  {
+    return SettlementOracle.Identifier({
+      liveness: identifier.liveness,
+      bondCurrency: identifier.bondCurrency,
+      minimumBond: identifier.minimumBond,
+      maximumBond: identifier.maximumBond,
+      marketCode: identifier.marketCode,
+      quoteName: identifier.quoteName,
+      enactmentDate: identifier.enactmentDate,
+      ipfsLink: identifier.ipfsLink
+    });
+  }
 
-  function submitClaim(Identifier calldata identifier, Data calldata data) external {
+  constructor(address _oracle) BaseOracle(_oracle) {}
+
+  function submitClaim(Identifier calldata identifier, Data calldata data) public {
+    return submitClaim(identifier, data, identifier.minimumBond, msg.sender);
+  }
+
+  function submitClaim(Identifier calldata identifier, Data calldata data, uint256 bondAmount) public {
+    return submitClaim(identifier, data, bondAmount, msg.sender);
+  }
+
+  function submitClaim(Identifier calldata identifier, Data calldata data, uint256 bondAmount, address asserter) public {
+    if (identifier.minimumBond > bondAmount || bondAmount > identifier.maximumBond) {
+      revert BondOutOfRange(identifier.minimumBond, identifier.maximumBond, bondAmount);
+    }
+
     bytes32 claimId = id(identifier);
     Claim storage claim = claims[claimId];
     if (claim.assertionId != 0) {
       revert ClaimAlreadySubmitted(claim.assertionId);
     }
 
-    uint256 bondAmount = oracle.getMinimumBond(address(bondCurrency));
-    bondCurrency.safeTransferFrom(msg.sender, address(this), bondAmount);
+    identifier.bondCurrency.approve(address(oracle), bondAmount);
+    identifier.bondCurrency.safeTransferFrom(msg.sender, address(this), bondAmount);
 
     bytes memory text = claimText(identifier, data);
-    address asserter = msg.sender;
     address callbackRecipient = address(this);
     address escalationManager = address(0); // default
 
-    bytes32 assertionId =
-      oracle.assertTruth(text, asserter, callbackRecipient, escalationManager, liveness, bondCurrency, bondAmount, 0, 0);
+    bytes32 assertionId = oracle.assertTruth(
+      text,
+      asserter,
+      callbackRecipient,
+      escalationManager,
+      identifier.liveness,
+      identifier.bondCurrency,
+      bondAmount,
+      0,
+      0
+    );
 
     claim.assertionId = assertionId;
     claim.data = abi.encode(data);


### PR DESCRIPTION
This is inspired by OptimisticGovernor from UMA oSnap. A dipusted claim does not obstruct the oracle process, but a new claim can be instantly made again. Another idea is to make successive claims to the same claimId have a escalation factor, meaning new proposals have some multiplier on the bond amount. This PR is equivalent to an escalation factor of 1x, ie. constant bond amount